### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # aoj-practice
+
+[![Run on Repl.it](https://repl.it/badge/github/TakayukiCho/aoj-practice)](https://repl.it/github/TakayukiCho/aoj-practice)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@TakayukiCho/aoj-practice-1).